### PR TITLE
Poprawienie wyniku progu covidowego

### DIFF
--- a/src/main/java/com/zduniusz/discord/commandlist/Infections.java
+++ b/src/main/java/com/zduniusz/discord/commandlist/Infections.java
@@ -27,7 +27,7 @@ public class Infections {
     }
 
     protected static String getCovidLevel() {
-        long polandPopulation = 37_660_000L;
+        long polandPopulation = 37_813_000L;
 
         if (Main.weeklyCovidStat == null)
             return "";


### PR DESCRIPTION
Zmaina z 37_660_000 na 37_813_000L żeby był on zgodny z koronawirusunas.pl